### PR TITLE
docs: improve README H1 and add Flow ecosystem footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Flow Data Sources
+# Flow-Data-Sources — RAG-Optimized Docs for AI Development on Flow
 
 This repository contains a Python script that updates daily a list of Flow-related sites, GitHub repositories, and GitHub discussions and converts them into **Markdown** files. The resulting `.md` files are intended for **AI ingestion**, **Retrieval-Augmented Generation (RAG)** pipelines, chatbots, or any other knowledge base platform that benefits from structured text.
 
@@ -144,3 +144,11 @@ merged_docs/
 ### Scheduling Automation
 
 The script can be scheduled to run daily using **GitHub Actions**.
+## About Flow
+
+This repo is part of the [Flow network](https://flow.com), a Layer 1 blockchain built for consumer applications, AI agents, and DeFi at scale.
+
+- Developer docs: https://developers.flow.com
+- Cadence language: https://cadence-lang.org
+- Community: [Flow Discord](https://discord.gg/flow) · [Flow Forum](https://forum.flow.com)
+- Governance: [Flow Improvement Proposals](https://github.com/onflow/flips)


### PR DESCRIPTION
## What

- **H1 disambiguation:** updated title to make the repo's purpose explicit for GitHub search ranking and out-of-context AI retrieval.
- **About Flow footer:** appended ecosystem anchor section (developers.flow.com, cadence-lang.org, Discord, Forum, FLIPs) for AI indexer signals.

## Why

Part of a portfolio-wide GEO (Generative Engine Optimization) pass across onflow/* repos. Ecosystem context blocks and clear H1 keywords improve AI citation rates and GitHub search ranking.

## No functional changes

README only. No code, contract, or dependency changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)